### PR TITLE
SAD-748 primary site should not use latest published settings

### DIFF
--- a/src/Foundation.Cms/Settings/SettingsService.cs
+++ b/src/Foundation.Cms/Settings/SettingsService.cs
@@ -283,12 +283,15 @@ namespace Foundation.Cms.Settings
 
             if (e.Content is SettingsBase)
             {
-                var id = ResolveSiteId();
-                if (id == Guid.Empty)
+                var parent = _contentRepository.Get<IContent>(e.Content.ParentLink);
+                var site = _siteDefinitionRepository.Get(parent.Name);
+
+                var id = site?.Id;
+                if (id == null || id == Guid.Empty)
                 {
                     return;
                 }
-                UpdateSettings(id, e.Content);
+                UpdateSettings(id.Value, e.Content);
             }
         }
 


### PR DESCRIPTION
1) It seems that the primary site uses whatever Layout Settings is last published, regardless which folder it's in. This is true whether you have additional domains configured or not. Just last published layout wins.
Root cause: The settings not associated with the site
2) Solution: Update settings by the site Id
3) Tested on Chrome