### PR TITLE
Support maintaining -U <user> -P <pw> in SqlCmd/resetup.cmd

### DIFF
--- a/setup.cmd
+++ b/setup.cmd
@@ -14,12 +14,12 @@ set APPCMD=%windir%\system32\inetsrv\appcmd.exe
 
 if "%~1" == "" goto loop
 
-for /f "tokens=1-5*" %%a in ("%*") do (
+for /f "tokens=1-8*" %%a in ("%*") do (
 	set APPNAME=%%a
 	set FOUNDATIONDOMAIN=%%b
 	set LICENSEPATH=%%c
 	set SQLSERVER=%%d
-	set ADDITIONAL_SQLCMD=%%e
+	set ADDITIONAL_SQLCMD=%%e %%f %%g %%h
 )
 goto main
 


### PR DESCRIPTION
This ensures that `-U <user> -P <password>` - if used in the sqlcmd call as prompted via **setup.cmd** (instead of default) - will be added among arguments to the **setup.cmd** call in **resetup.cmd**. 